### PR TITLE
[WIP] Make package load and fix registration

### DIFF
--- a/src/DataDepsPaths.jl
+++ b/src/DataDepsPaths.jl
@@ -4,21 +4,29 @@ using DataDeps: register, AbstractDataDep
 using FilePathsBase
 
 
+struct Satisfier
+    satisfies # DataDepPath → Bool
+    resolve # () → AbstractPath
+end
+Satisfier((satisfies, resolve)) =
+    Satisfier(satisfies, resolve)
+
 struct DataDependency <: AbstractDataDep
     name::String
     message::String
     satisfiers::Vector{Satisfier}
 end
 
-struct Satisfier
-    satisfies # DataDepPath → Bool
-    resolve # () → AbstractPath
-end
-
 struct DataDepPath # Should we actually subtype AbstractPath here?
     name::String
     parts::Vector{String}
 end
+
+struct DataDepPathRegistration
+    satisfiers::Vector{Satisfier}
+end
+DataDepPathRegistration(satisfiers...) =
+    DataDepPathRegistration(collect(Satisfier.(satisfiers)))
 
 function satisfy(datadep::DataDependency, dd_path::DataDepPath)
     @assert(datadep.name == dd_path.name)

--- a/src/multistage_resolution.jl
+++ b/src/multistage_resolution.jl
@@ -1,5 +1,4 @@
-
-using DataDeps: run_checksum, run_fetch, run_postfetch
+using DataDeps: run_checksum, run_fetch, run_post_fetch
 
 struct MultistageResolution
     remote_path
@@ -11,6 +10,6 @@ end
 function (msr::MultistageResolution)()
     fetched_paths = run_fetch(msr.fetch_method, msr.remote_path)
     run_checksum(fetched_paths, msr.hash)
-    run_postfetch(msr.path_fetch_method)
+    run_post_fetch(msr.path_fetch_method)
 end
 

--- a/src/satisfiers.jl
+++ b/src/satisfiers.jl
@@ -31,7 +31,7 @@ function SatisfierLookup(satisfiers)
     function add_sat!(func)
         # it is a dynamic satisfier
         dynamic === nothing || error("You can only have 1 dynamic satisfier, per folder.")
-        
+
         # Convert the result into an AbstractResolver (static satisfiers do this immediately)
         dynamic = pathpart -> convert(AbstractResolver, func(pathpart))
     end
@@ -97,10 +97,3 @@ function resolve(satisfier_lookup::SatisfierLookup, localdir, pathparts_head, pa
     subdir = mkpath(joinpath(localdir, pathparts_head))
     return resolve(subresolver, subdir, pathparts_tail...)
 end
-
-
-
-
-
-
-


### PR DESCRIPTION
Fixed struct definition order
Added DataDepPathRegistration per README example
Fixed DataDeps function imports
Misc. whitespace cleanup

TODO: Make it possible to execute registered satisfiers